### PR TITLE
Fix Thermal Expansion support?

### DIFF
--- a/stanhebben/minetweaker/MineTweaker.java
+++ b/stanhebben/minetweaker/MineTweaker.java
@@ -91,7 +91,7 @@ import stanhebben.minetweaker.mods.te.ThermalExpansionSupport;
  * 
  * @author Stan Hebben
  */
-@Mod(modid = "MineTweaker", name = "MineTweaker", version = MineTweaker.MCVERSION + "-2.1.2")
+@Mod(modid = "MineTweaker", name = "MineTweaker", version = MineTweaker.MCVERSION + "-2.1.2", dependencies = "before:ThermalExpansion")
 @NetworkMod(clientSideRequired = true, serverSideRequired = true, channels = {TweakerPacketHandler.CHANNEL_SERVERSCRIPT}, packetHandler = TweakerPacketHandler.class)
 public class MineTweaker {
 	//#ifdef MC152

--- a/stanhebben/minetweaker/MineTweaker.java
+++ b/stanhebben/minetweaker/MineTweaker.java
@@ -91,7 +91,7 @@ import stanhebben.minetweaker.mods.te.ThermalExpansionSupport;
  * 
  * @author Stan Hebben
  */
-@Mod(modid = "MineTweaker", name = "MineTweaker", version = MineTweaker.MCVERSION + "-2.1.2", dependencies = "before:ThermalExpansion")
+@Mod(modid = "MineTweaker", name = "MineTweaker", version = MineTweaker.MCVERSION + "-2.1.2")
 @NetworkMod(clientSideRequired = true, serverSideRequired = true, channels = {TweakerPacketHandler.CHANNEL_SERVERSCRIPT}, packetHandler = TweakerPacketHandler.class)
 public class MineTweaker {
 	//#ifdef MC152


### PR DESCRIPTION
I was looking into why Thermal Expansion recipes weren't working with MineTweaker again after giving up the first time. Looking at IMC messages, it seems like they might only get sent before a mod reaches post-init state..? I'd love it if you could compile the mod for me to test, you don't have to accept the pull request right now.

By the way, `dependencies = "before:ThermalExpansion"` doesn't mean TE is required (that would be `required-before`), it'll just make sure it's loaded before TE if it **is** there.

**Update:** Description outdated, see comments below.
